### PR TITLE
There is a newer vessel

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Also make sure to check out the [`Canister`](https://kritzcreek.github.io/motoko
 
 ## Zero to hero (Step-by-step)
 - Install [dfx](https://sdk.dfinity.org/docs/quickstart/quickstart.html#download-and-install)
-- Install [vessel](https://github.com/kritzcreek/vessel/releases/tag/v0.5.1-alpha)
+- Install [vessel](https://github.com/kritzcreek/vessel/releases/tag/v0.5.1)
 ```bash
 git clone https://github.com/kritzcreek/ic101.git
 cd ic101


### PR DESCRIPTION
Re-point the link to a newer `vessel` release.

Please also consider supporting a newer `dfx`:
``` diff
diff --git a/dfx.json b/dfx.json
index 1d47d6e..2606913 100644
--- a/dfx.json
+++ b/dfx.json
@@ -17,7 +17,7 @@
       "packtool": "vessel sources"
     }
   },
-  "dfx": "0.6.4",
+  "dfx": "0.6.7",
   "networks": {
     "local": {
       "bind": "127.0.0.1:8000",
@@ -31,4 +31,4 @@
     }
   },
   "version": 1
-}
\ No newline at end of file
+}

```
